### PR TITLE
update to latest mruby

### DIFF
--- a/src/murmurhash2.c
+++ b/src/murmurhash2.c
@@ -70,7 +70,7 @@ void
 mrb_mruby_murmurhash2_gem_init(mrb_state *mrb)
 {
   struct RClass *mMurmurhash1 = mrb_define_module(mrb, "MurmurHash2");
-  mrb_define_class_method(mrb, mMurmurhash1, "digest", mrb_murmurhash2_digest, ARGS_REQ(1));
+  mrb_define_class_method(mrb, mMurmurhash1, "digest", mrb_murmurhash2_digest, MRB_ARGS_REQ(1));
 }
 
 void


### PR DESCRIPTION
on latest mruby, ARGS_XXX is deprecated.
ARGS_XXX replaced with MRB_AGRS_XXX
